### PR TITLE
Ensure MemCache connection closed

### DIFF
--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -62,7 +62,9 @@ module KomachiHeartbeat
 
     def memcached_connection_check
       memcached_server_names.each do |memcached_server_name|
-        MemCache.new(memcached_server_name).stats
+        memcache = MemCache.new(memcached_server_name)
+        memcache.stats
+        memcache.reset
       end
     end
 


### PR DESCRIPTION
MemCache connection is sometimes too long-lived on ruby 2.1.
