### PR TITLE
Remove MySQL-style backticks for PostgreSQL compatibility

### DIFF
--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -32,7 +32,7 @@ module KomachiHeartbeat
 
     def db_connection_check
       connection_database_class_names.each do |klass|
-        klass.constantize.connection.execute "SELECT * FROM `schema_migrations` LIMIT 1"
+        klass.constantize.connection.execute "SELECT * FROM schema_migrations LIMIT 1"
       end
     end
 


### PR DESCRIPTION
Postgre raises error when using backticks:
   (6.6ms)  SELECT * FROM `schema_migrations` LIMIT 1
   PG::SyntaxError: ERROR:  syntax error at or near "`"