### PR TITLE
Support heartbeat badge

### DIFF
--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -26,7 +26,7 @@ module KomachiHeartbeat
       @badge_color = GREEN
 
       respond_to do |format|
-        format.svg
+        format.svg { }
         format.any { render text: "heartbeat:ok", status: 200 }
       end
     end

--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -2,10 +2,18 @@ require_dependency "komachi_heartbeat/application_controller"
 
 module KomachiHeartbeat
   class HeartbeatController < ApplicationController
+    RED   = "#e05d44"
+    GREEN = "#4c1"
 
     unless Rails.env.test?
       rescue_from Exception do |exception|
-        head :internal_server_error
+        @message = "NG"
+        @badge_color = RED
+
+        respond_to do |format|
+          format.svg { render :index }
+          format.any { head :internal_server_error }
+        end
       end
     end
 
@@ -14,7 +22,13 @@ module KomachiHeartbeat
       redis_connection_check if redis_check?
       memcached_connection_check if memcached_check?
 
-      render text: "heartbeat:ok", status: 200
+      @message = "ok"
+      @badge_color = GREEN
+
+      respond_to do |format|
+        format.svg
+        format.any { render text: "heartbeat:ok", status: 200 }
+      end
     end
 
     def version

--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -5,15 +5,13 @@ module KomachiHeartbeat
     RED   = "#e05d44"
     GREEN = "#4c1"
 
-    unless Rails.env.test?
-      rescue_from Exception do |exception|
-        @message = "NG"
-        @badge_color = RED
+    rescue_from Exception do |exception|
+      @message = "NG"
+      @badge_color = RED
 
-        respond_to do |format|
-          format.svg { render :index }
-          format.any { head :internal_server_error }
-        end
+      respond_to do |format|
+        format.svg { render :index }
+        format.any { head :internal_server_error }
       end
     end
 

--- a/app/views/komachi_heartbeat/heartbeat/index.svg.erb
+++ b/app/views/komachi_heartbeat/heartbeat/index.svg.erb
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-opacity=".3"/>
+    <stop offset="1" stop-opacity=".5"/>
+  </linearGradient>
+  <rect rx="4" width="99" height="18" fill="#555"/>
+  <rect rx="4" x="63" width="36" height="18" fill="<%= @badge_color %>"/>
+  <path fill="<%= @badge_color %>" d="M63 0h4v18h-4z"/>
+  <rect rx="4" width="99" height="18" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="32.5" y="14" fill="#010101" fill-opacity=".3">heartbeat</text>
+    <text x="32.5" y="13">heartbeat</text>
+    <text x="80" y="14" fill="#010101" fill-opacity=".3"><%= @message %></text>
+    <text x="80" y="13"><%= @message %></text>
+  </g>
+</svg>

--- a/lib/komachi_heartbeat.rb
+++ b/lib/komachi_heartbeat.rb
@@ -1,5 +1,6 @@
 require "komachi_heartbeat/config"
 require "komachi_heartbeat/engine"
+require "komachi_heartbeat/railtie"
 
 module KomachiHeartbeat
   def self.config

--- a/lib/komachi_heartbeat/railtie.rb
+++ b/lib/komachi_heartbeat/railtie.rb
@@ -1,0 +1,9 @@
+module KomachiHeartbeat
+  class Railtie < ::Rails::Railtie
+    initializer "komachi_heartbeat.register_mime" do
+      unless Mime[:svg]
+        Mime::Type.register "image/svg+xml", :svg
+      end
+    end
+  end
+end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -25,29 +25,32 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
       allow(mock_memcache).to receive(:stats)
       allow(mock_memcache).to receive(:reset)
       allow(MemCache).to receive(:new){ mock_memcache }
+    end
 
+    subject do
       # exercise
       get "index", params
+      response
     end
 
     let(:params) { { use_route: 'ops', format: format } }
 
-    subject { response }
+    context "When successful" do
+      context "When default format" do
+        let(:format) { nil }
 
-    context "When default format" do
-      let(:format) { nil }
+        it { should be_success }
+        its(:body) { should eq "heartbeat:ok" }
+      end
 
-      it { should be_success }
-      its(:body) { should eq "heartbeat:ok" }
-    end
+      context "When svg format" do
+        let(:format) { "svg" }
 
-    context "When svg format" do
-      let(:format) { "svg" }
+        it { should be_success }
 
-      it { should be_success }
-
-      its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
-      its(:content_type) { should eq "image/svg+xml" }
+        its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
+        its(:content_type) { should eq "image/svg+xml" }
+      end
     end
   end
 end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -38,5 +38,15 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
       it { should be_success }
       its(:body) { should eq "heartbeat:ok" }
     end
+
+    context "When svg format" do
+      let(:format) { "svg" }
+
+      it { should be_success }
+
+      # NOTE: can not get response body...
+      its(:body) { should eq "" }
+      its(:content_type) { should eq "image/svg+xml" }
+    end
   end
 end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -49,6 +49,30 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
         it { should be_success }
 
         its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
+        its(:body) { should include '<text x="80" y="13">ok</text>' }
+        its(:content_type) { should eq "image/svg+xml" }
+      end
+    end
+
+    context "When error is occurred" do
+      before do
+        allow(controller).to receive(:db_check?) { raise "something wrong!" }
+      end
+
+      context "When default format" do
+        let(:format) { nil }
+
+        its(:status) { should eq 500 }
+        its(:body) { should eq " " }
+      end
+
+      context "When svg format" do
+        let(:format) { "svg" }
+
+        it { should be_success }
+
+        its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
+        its(:body) { should include '<text x="80" y="13">NG</text>' }
         its(:content_type) { should eq "image/svg+xml" }
       end
     end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -63,7 +63,10 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
         let(:format) { nil }
 
         its(:status) { should eq 500 }
-        its(:body) { should eq " " }
+
+        # NOTE: Rails 3.2~4.1 is " "
+        #   Rails 4.2+ is ""
+        its(:body) { should match /^[ ]*$/ }
       end
 
       context "When svg format" do

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -16,6 +16,8 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
   end
 
   describe "GET index" do
+    render_views
+
     before do
       # setup
       # `memcache_mock` does not support stats and reset
@@ -44,8 +46,7 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
 
       it { should be_success }
 
-      # NOTE: can not get response body...
-      its(:body) { should eq "" }
+      its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
       its(:content_type) { should eq "image/svg+xml" }
     end
   end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -25,9 +25,18 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
       allow(MemCache).to receive(:new){ mock_memcache }
 
       # exercise
-      get "index", :use_route => 'ops'
+      get "index", params
     end
+
+    let(:params) { { use_route: 'ops', format: format } }
+
     subject { response }
-    it { should be_success }
+
+    context "When default format" do
+      let(:format) { nil }
+
+      it { should be_success }
+      its(:body) { should eq "heartbeat:ok" }
+    end
   end
 end


### PR DESCRIPTION
I add svg format heartbeat (e.g. `/ops/heartbeat.svg`)

# Example
## heartbeat:ok
![image](https://cloud.githubusercontent.com/assets/608755/12510390/e37c609a-c14c-11e5-8e5a-e6f6b13f22e5.png)

## error
![image](https://cloud.githubusercontent.com/assets/608755/12510397/f5edfc8e-c14c-11e5-912d-67c121ea3291.png)