### PR TITLE
use `render :plain` instead of `render :text`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
   - 2.3.0
   - ruby-head
 gemfile:
-  - gemfiles/rails3_2.gemfile
-  - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile
   - gemfiles/rails4_2.gemfile
   - gemfiles/rails5_0.gemfile

--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -25,7 +25,7 @@ module KomachiHeartbeat
 
       respond_to do |format|
         format.svg { }
-        format.any { render text: "heartbeat:ok", status: 200 }
+        format.any { render plain: "heartbeat:ok", status: 200 }
       end
     end
 

--- a/gemfiles/rails3_2.gemfile
+++ b/gemfiles/rails3_2.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem 'rails', "~> 3.2.0"
-
-gemspec path: '../'

--- a/gemfiles/rails4_0.gemfile
+++ b/gemfiles/rails4_0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem 'rails', "~> 4.0.0"
-
-gemspec path: '../'

--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -2,4 +2,14 @@ source "https://rubygems.org"
 
 gem 'rails', "~> 4.1.0"
 
+# mime-type v3.0 (depends on mime-types-data) requires Ruby version >= 2.0.
+if Gem::Version.create(RUBY_VERSION.dup) < Gem::Version.create("2.0")
+  gem "mime-types", "< 3.0"
+end
+
+# listen v3.1.0 requires Ruby version >= 2.2.3, ~> 2.2.
+if Gem::Version.create(RUBY_VERSION.dup) < Gem::Version.create("2.2")
+  gem "listen", "< 3.1.0"
+end
+
 gemspec path: '../'

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -2,4 +2,14 @@ source "https://rubygems.org"
 
 gem 'rails', "~> 4.2.0"
 
+# mime-type v3.0 (depends on mime-types-data) requires Ruby version >= 2.0.
+if Gem::Version.create(RUBY_VERSION.dup) < Gem::Version.create("2.0")
+  gem "mime-types", "< 3.0"
+end
+
+# listen v3.1.0 requires Ruby version >= 2.2.3, ~> 2.2.
+if Gem::Version.create(RUBY_VERSION.dup) < Gem::Version.create("2.2")
+  gem "listen", "< 3.1.0"
+end
+
 gemspec path: '../'

--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 3.2.11"
+  s.add_dependency "rails", ">= 4.1.0"
   s.add_dependency "redis"
 
   # s.add_dependency "jquery-rails"


### PR DESCRIPTION
`render :text` is deprecated in rails5.rc1.

```
DEPRECATION WARNING: `render :text` is deprecated because it does not
actually render a `text/plain` response.
Switch to `render plain: 'plain text'` to render as `text/plain`,
`render html: '<strong>HTML</strong>'` to render as `text/html`,
or `render body: 'raw'` to match the deprecated behavior and
render with the default Content-Type, which is `text/plain`.
```

`render :plain` is released since v4.1.0.rc1. so update dependet version.

**NOTE**: Drop support rails v3.1, v4.0.