### PR TITLE
Bugfixed: /ops/heartbeat returns svg format with curl or wget

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 KomachiHeartbeat::Engine.routes.draw do
-  get "heartbeat", :to => "heartbeat#index"
+  get "heartbeat", :to => "heartbeat#index", defaults: { format: "txt" }
   get "version", :to => "heartbeat#version"
 
   get "stats/worker", :to => "stats#worker"


### PR DESCRIPTION
This is regression of  #14 :cry: 

`komachi_heartbeat/heartbeat#index` is expected to return the A by default. But this return when using `curl` or `wget`

So I fixed. 

# Example
## Before
```sh
$ curl http://localhost:3000/ops/heartbeat
<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">
  <linearGradient id="a" x2="0" y2="100%">
    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
    <stop offset=".9" stop-opacity=".3"/>
    <stop offset="1" stop-opacity=".5"/>
  </linearGradient>
  <rect rx="4" width="99" height="18" fill="#555"/>
  <rect rx="4" x="63" width="36" height="18" fill="#4c1"/>
  <path fill="#4c1" d="M63 0h4v18h-4z"/>
  <rect rx="4" width="99" height="18" fill="url(#a)"/>
  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
    <text x="32.5" y="14" fill="#010101" fill-opacity=".3">heartbeat</text>
    <text x="32.5" y="13">heartbeat</text>
    <text x="80" y="14" fill="#010101" fill-opacity=".3">ok</text>
    <text x="80" y="13">ok</text>
  </g>
</svg>
```

## After
```sh
$ curl http://localhost:3000/ops/heartbeat
heartbeat:ok
```

# NOTE
This PR is depends on #18 . 

Please merge the #18 previously. after I rebase this PR :bow:
