### PR TITLE
Update db connection check SQL

### DIFF
--- a/app/controllers/komachi_heartbeat/heartbeat_controller.rb
+++ b/app/controllers/komachi_heartbeat/heartbeat_controller.rb
@@ -44,7 +44,7 @@ module KomachiHeartbeat
 
     def db_connection_check
       connection_database_class_names.each do |klass|
-        klass.constantize.connection.execute "SELECT * FROM schema_migrations LIMIT 1"
+        klass.constantize.connection.execute "SELECT 1"
       end
     end
 


### PR DESCRIPTION
Update db connection check SQL for Rails application which doesn't use migration.
ex. [ridgepole](https://github.com/winebarrel/ridgepole) doesn't make `schema_migrations` table.