### PR TITLE
Add: stats/worker response

### DIFF
--- a/app/controllers/komachi_heartbeat/stats_controller.rb
+++ b/app/controllers/komachi_heartbeat/stats_controller.rb
@@ -18,8 +18,7 @@ module KomachiHeartbeat
     end
 
     def sidekiq_stats
-      stats = Sidekiq::Stats.new
-      { enqueued: stats.enqueued, processed: stats.processed }
+      JSON.parse(Sidekiq::Stats.new.to_json)['stats']
     end
 
     def resque_stats

--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'mock_redis'
   s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'sidekiq'
 end

--- a/spec/controllers/komachi_heartbeat/stats_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/stats_controller_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe KomachiHeartbeat::StatsController, type: :controller do
   describe 'GET worker' do
     context 'Sidekiq' do
-      require 'sidekiq/api'
-      it 'returns full Sidekiq::Stats attributes' do
+      it 'returns full Sidekiq::Stats attributes', :skip => RUBY_VERSION < '2.0.0' do
+        require 'sidekiq/api'
         get :worker
         expect(JSON.parse(response.body)).to include(
           'processed', 'failed', 'scheduled_size', 'retry_size', 'dead_size',

--- a/spec/controllers/komachi_heartbeat/stats_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/stats_controller_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe KomachiHeartbeat::StatsController, type: :controller do
+  describe 'GET worker' do
+    context 'Sidekiq' do
+      require 'sidekiq/api'
+      it 'returns full Sidekiq::Stats attributes' do
+        get :worker
+        expect(JSON.parse(response.body)).to include(
+          'processed', 'failed', 'scheduled_size', 'retry_size', 'dead_size',
+          'processes_size', 'default_queue_latency', 'workers_size', 'enqueued'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey.

I want to get Sidekiq total process count.

But when I configured `worker_stats_enabled = true`, then I get response 'enqueued' and 'processed' attributes.

Sidekiq::Stat has some attributes.

(ex)

```
[1] pry(#<KomachiHeartbeat::StatsController>)> stats
=> #<Sidekiq::Stats:0x007fce774f0db0
 @stats={:processed=>114781, :failed=>61659, :scheduled_size=>0, :retry_size=>0, :dead_size=>0, :processes_size=>0, :default_queue_latency=>0, :workers_size=>0, :enqueued=>24}>
```

What about returning all these attributes?

---

![image](https://cloud.githubusercontent.com/assets/1255116/25278173/c55ae66c-26dc-11e7-87be-06e3f5ee5206.png)
