### PR TITLE
CI against rails 5.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
   allow_failures:
     # NOTE: There are unstable versions
     - rvm: ruby-head
-    - gemfile: gemfiles/rails5_1.gemfile # TODO: Remove this after rails5.1 is released!
 
   exclude:
     # NOTE: SystemStackError: stack level too deep when Ruby 2.4 + Rails 4.1

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rails', "~> 5.1.0.rc1"
+gem 'rails', "~> 5.1.0"
 
 gemspec path: '../'

--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'mock_redis'
   s.add_development_dependency 'test-unit'
-  s.add_development_dependency 'sidekiq'
+  s.add_development_dependency 'sidekiq', '< 5.0.0' # sidekiq 5.x+ requires MRI 2.2.2+
 end


### PR DESCRIPTION
Rails 5.1.0 is released! 🎉
http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/