### PR TITLE
redis to development dependency

### DIFF
--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.1.0"
 
-  # s.add_dependency "jquery-rails"
-
   s.add_development_dependency "redis"
   s.add_development_dependency "memcache-client"
   s.add_development_dependency "dalli"

--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.1.0"
-  s.add_dependency "redis"
 
   # s.add_dependency "jquery-rails"
 
+  s.add_development_dependency "redis"
   s.add_development_dependency "memcache-client"
   s.add_development_dependency "dalli"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
# Why ?
My app doesn't use redis. So I want to use `/ops/heartbeat` for **only** DB connection checking.

But `komachi_heartbeat` requires `redis` gem with runtime dependency.
I don't want to install `redis` gem for **only** `komachi_heartbeat`!

redis connection checking is optional in this gem.

I think that redis should be development dependency rather than runtime dependency.