### PR TITLE
CI against ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,9 @@ matrix:
       gemfile: gemfiles/rails5_2.gemfile
     - rvm: 2.1.2
       gemfile: gemfiles/rails5_2.gemfile
+
+    # NOTE: Rails 4.2 doesn't work on MRI 2.6+
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails4_2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.0
   - 2.4.1
   - 2.5.0
+  - 2.6.0
   - ruby-head
 gemfile:
   - gemfiles/rails4_1.gemfile
@@ -31,6 +32,8 @@ matrix:
     - rvm: 2.4.1
       gemfile: gemfiles/rails4_1.gemfile
     - rvm: 2.5.0
+      gemfile: gemfiles/rails4_1.gemfile
+    - rvm: 2.6.0
       gemfile: gemfiles/rails4_1.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails4_1.gemfile

--- a/komachi_heartbeat.gemspec
+++ b/komachi_heartbeat.gemspec
@@ -30,7 +30,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'growl'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
-  s.add_development_dependency 'mock_redis'
+  s.add_development_dependency 'mock_redis', '< 0.19.0' # mock_redis 0.19.0+ resuires MRI 2.2.0+
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'sidekiq', '< 5.0.0' # sidekiq 5.x+ requires MRI 2.2.2+
+  s.add_development_dependency 'rake', '< 12.3.0' # rake 12.3.0+ requires MRI 2.0.0+
+  s.add_development_dependency 'rb-inotify', '< 0.10.0' # rb-inotify 0.10.0+ requires MRI 2.2.0+
 end

--- a/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
+++ b/spec/controllers/komachi_heartbeat/heartbeat_controller_spec.rb
@@ -5,7 +5,7 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
   describe "GET version" do
     before { get "version" }
     subject { response }
-    it { should be_success }
+    it { should be_successful }
 
     describe "body" do
       subject { OpenStruct.new(JSON.load(response.body)) }
@@ -39,14 +39,14 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
       context "When default format" do
         let(:format) { nil }
 
-        it { should be_success }
+        it { should be_successful }
         its(:body) { should eq "heartbeat:ok" }
       end
 
       context "When svg format" do
         let(:format) { "svg" }
 
-        it { should be_success }
+        it { should be_successful }
 
         its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
         its(:body) { should include '<text x="80" y="13">ok</text>' }
@@ -72,7 +72,7 @@ describe KomachiHeartbeat::HeartbeatController, type: :controller do
       context "When svg format" do
         let(:format) { "svg" }
 
-        it { should be_success }
+        it { should be_successful }
 
         its(:body) { should start_with '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="18">' }
         its(:body) { should include '<text x="80" y="13">NG</text>' }


### PR DESCRIPTION
* Add ruby 2.6.0 to build matrix
* Fixed. can not `bundle install` on ruby < 2.2
* Resolved deprecation warning on Rails 5.2
* Exclude rails 4.2 + ruby 2.6 and head from build matrix