### PR TITLE
Fix local spec execution

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
Im my environment, rspec fails.
It happend because of sprockets v4.
https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs

```
$ ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin18]

$ export BUNDLE_GEMFILE=$PWD/gemfiles/rails5_2.gemfile
$ bundle install

$ bundle exec rspec
bundler: failed to load command: rspec (/Users/takanamito/.rbenv/versions/2.7.0/bin/rspec)
Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js`
But did not, please create this file and use it to link any assets that need
to be rendered by your app:

Example:
  //= link_tree ../images
  //= link_directory ../javascripts .js
  //= link_directory ../stylesheets .css
and restart your server
...
```

So, I added manifest.js and spec run successfully.