### PR TITLE
Rails6 multidb heartbeat check

### DIFF
--- a/lib/komachi_heartbeat/config.rb
+++ b/lib/komachi_heartbeat/config.rb
@@ -1,13 +1,18 @@
 module KomachiHeartbeat
   class Config
     include ActiveSupport::Configurable
-    config_accessor :application_version, :application_name, :db_check_enabled, :redis_check_enabled, :memcached_check_enabled, :database_class_names, :memcached_server_names, :redis_servers, :worker_stats_enabled, :revision_path
+    config_accessor :application_version, :application_name, :db_check_enabled, :redis_check_enabled, :memcached_check_enabled, :database_class_names, :multidb_check_enabled, :multidb_role_and_class_names, :memcached_server_names, :redis_servers, :worker_stats_enabled, :revision_path
 
     configure do |config|
       config.application_name = "Unknown"
       config.application_version = "Unknown"
       config.db_check_enabled = true
       config.database_class_names = ["ActiveRecord::Base"]
+
+      config.multidb_check_enabled = false
+      config.multidb_role_and_class_names = [
+        { role: :primary, class: 'ActiveRecord::Base'}
+      ]
 
       config.redis_check_enabled = false
       config.redis_servers = [{host: "localhost", port: 6379, db: 0}]


### PR DESCRIPTION
Implements for multi db heartbeat check.

Sample application config is below.

database.yml

```
development:
  primary:
    <<: *default
    host: foo_host
    database: sample_db
  replica:
    <<: *default
    host: bar_host
    database: sample_db
    replica: true
```

application_record.rb

```
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
  connects_to database: { writing: :primary, reading: :replica }
  ...
end
```

config/application.rb

```
...
config.heartbeat.multidb_check_enabled = true
config.heartbeat.multidb_role_and_class_names = [
  { role: :reading, class: 'ApplicationRecord' }
]
...
```

Rails6 multidb has db role and select it by `connected_to(role: ${role})` method.
So I made a new config value `multidb_role_and_class_names` that specify role and class to execute healthcheck .