### PR TITLE
Drop old versions of ruby CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ gemfile:
   - gemfiles/rails5_0.gemfile
   - gemfiles/rails5_1.gemfile
   - gemfiles/rails5_2.gemfile
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v '<2'
 script: bundle exec rspec
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.2
-  - 2.2.5
-  - 2.3.0
-  - 2.4.1
   - 2.5.0
   - 2.6.0
   - ruby-head
 gemfile:
-  - gemfiles/rails4_1.gemfile
   - gemfiles/rails4_2.gemfile
   - gemfiles/rails5_0.gemfile
   - gemfiles/rails5_1.gemfile
@@ -28,36 +21,6 @@ matrix:
     - rvm: ruby-head
 
   exclude:
-    # NOTE: SystemStackError: stack level too deep when Ruby 2.4 + Rails 4.1
-    - rvm: 2.4.1
-      gemfile: gemfiles/rails4_1.gemfile
-    - rvm: 2.5.0
-      gemfile: gemfiles/rails4_1.gemfile
-    - rvm: 2.6.0
-      gemfile: gemfiles/rails4_1.gemfile
-    - rvm: ruby-head
-      gemfile: gemfiles/rails4_1.gemfile
-
-    # NOTE: rails 5.0+ requirements ruby 2.2.2+
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails5_0.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails5_0.gemfile
-    - rvm: 2.1.2
-      gemfile: gemfiles/rails5_0.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails5_1.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails5_1.gemfile
-    - rvm: 2.1.2
-      gemfile: gemfiles/rails5_1.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails5_2.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails5_2.gemfile
-    - rvm: 2.1.2
-      gemfile: gemfiles/rails5_2.gemfile
-
     # NOTE: Rails 4.2 doesn't work on MRI 2.6+
     - rvm: 2.6.0
       gemfile: gemfiles/rails4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.5.8
   - 2.6.6
+  - 2.7.1
   - ruby-head
 gemfile:
   - gemfiles/rails4_2.gemfile
@@ -23,6 +24,8 @@ matrix:
   exclude:
     # NOTE: Rails 4.2 doesn't work on MRI 2.6+
     - rvm: 2.6.6
+      gemfile: gemfiles/rails4_2.gemfile
+    - rvm: 2.7.1
       gemfile: gemfiles/rails4_2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.5.0
-  - 2.6.0
+  - 2.5.8
+  - 2.6.6
   - ruby-head
 gemfile:
   - gemfiles/rails4_2.gemfile
@@ -22,7 +22,7 @@ matrix:
 
   exclude:
     # NOTE: Rails 4.2 doesn't work on MRI 2.6+
-    - rvm: 2.6.0
+    - rvm: 2.6.6
       gemfile: gemfiles/rails4_2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - gemfiles/rails5_0.gemfile
   - gemfiles/rails5_1.gemfile
   - gemfiles/rails5_2.gemfile
+  - gemfiles/rails6_0.gemfile
 before_install: gem install bundler -v '<2'
 script: bundle exec rspec
 branches:

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'rails', "~> 4.2.0"
+gem 'sqlite3', "~> 1.3.13"
 
 # mime-type v3.0 (depends on mime-types-data) requires Ruby version >= 2.0.
 if Gem::Version.create(RUBY_VERSION.dup) < Gem::Version.create("2.0")

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem 'rails', "~> 5.0.0"
+gem 'sqlite3', "~> 1.3.13"
 
 gemspec path: '../'

--- a/gemfiles/rails6_0.gemfile
+++ b/gemfiles/rails6_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'rails', "~> 6.0.0"
+
+gemspec path: '../'


### PR DESCRIPTION
ref: CI is broken #32

- Drop old versions of ruby and rails CI matrix
- Bump ruby versions
- CI against ruby 2.7 and rails 6.0